### PR TITLE
move jshint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/bubkoo/dataurl-to-blob/issues"
   },
   "homepage": "https://github.com/bubkoo/dataurl-to-blob#readme",
-  "dependencies": {
+  "devDependencies": {
     "jshint": "^2.9.2"
   }
 }


### PR DESCRIPTION
resolves #1 and stops phantomjs from being downloaded by consuming apps